### PR TITLE
Fix import path for bitcask

### DIFF
--- a/bitcask_test.go
+++ b/bitcask_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 )
 
 func benchBitcask_Get(b *testing.B, options ...bitcask.Option) {


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇